### PR TITLE
Add 0-star rating as default value to fix bug

### DIFF
--- a/portfolio/src/main/webapp/contact.html
+++ b/portfolio/src/main/webapp/contact.html
@@ -38,6 +38,7 @@
           <label for="star2-input"><i class="material-icons">star_border</i></label>
           <input type="radio" name="rating" id="star1-input" class="hide" value="1">
           <label for="star1-input"><i class="material-icons">star_border</i></label>
+          <input type="radio" name="rating" id="star0-input" class="hide" value="0" checked>
         </div>
         <label for="textfield" id="comment-label">Comment:</label>
         <textarea id="textfield" name="textfield" rows="10" cols="50" placeholder="What are you thinking???"></textarea>


### PR DESCRIPTION
In the last deployment whenever the user sent a comment without choosing a rating, the server would return an error. This PR is meant to fix that bug. 